### PR TITLE
Update QgsFmvUtils.py

### DIFF
--- a/code/utils/QgsFmvUtils.py
+++ b/code/utils/QgsFmvUtils.py
@@ -625,9 +625,15 @@ def CornerEstimationWithoutOffsets(packet):
         headingAngle = packet.GetPlatformHeadingAngle()
         sensorRelativeAzimut = packet.GetSensorRelativeAzimuthAngle()
         targetWidth = packet.GettargetWidth()
+        slantRange = packet.GetSlantRange()
 
         if sensorLatitude == 0:
             return False
+        
+        if targetWidth == 0 and slantRange != 0:
+            targetWidth = 2*slantRange*tan(radians(sensorHorizontalFOV/2))
+        else:
+            targetWidth = 100
 
         initialPoint = (sensorLongitude, sensorLatitude)
         destPoint = (frameCenterLon, frameCenterLat)


### PR DESCRIPTION
On my videos UAS Datalink Version 8.0 I got always the Target Width attribute that is 0.

In this case we compute the Target Width with the slate range and sensor hz field of view.

If the target width remains 0, we could give a default value like 100 so the footprint will not be displayed as a point.