### PR TITLE
correct meta reader when skip button is used

### DIFF
--- a/code/klvdata/streamparser.py
+++ b/code/klvdata/streamparser.py
@@ -25,6 +25,8 @@
 
 from QGIS_FMV.klvdata.element import UnknownElement
 from QGIS_FMV.klvdata.klvparser import KLVParser
+from QGIS_FMV.utils.QgsUtils import QgsUtils as qgsu
+
 try:
     from pydevd import *
 except ImportError:
@@ -45,6 +47,8 @@ class StreamParser:
 
     def __next__(self):
         key, value = next(self.iter_stream)
+        #qgsu.showUserAndLogMessage(
+        #    "", "Streamparser key: " + str(key) + " value: " + str(value), onlyLog=True)
         if key in self.parsers:
             return self.parsers[key](value)
         else:

--- a/code/player/QgsManager.py
+++ b/code/player/QgsManager.py
@@ -51,7 +51,7 @@ class FmvManager(QDockWidget, Ui_ManagerWindow):
         # min_buffer_size x buffer_intervall = Miliseconds buffer time
         self.min_buffer_size = min_buffer_size
 
-        self.actionOpen_Stream.setVisible(False)
+        self.actionOpen_Stream.setVisible(True)
 
         self.VManager.viewport().installEventFilter(self)
 
@@ -192,7 +192,7 @@ class FmvManager(QDockWidget, Ui_ManagerWindow):
         # Not Play if not have metadata
         if self.pBars[str(model.row())].value() < 100:
             return
-
+        
         path = self.VManager.item(model.row(), 3).text()
         self.ToggleActiveRow(model.row())
 


### PR DESCRIPTION
-When we use the skip button, we can land on a video part that does not have metadata yet. We need to pause the video for 2 sec until the buffer is newly created. 

-Small fix for streamparser