### PR TITLE
Update misb0102.py

### DIFF
--- a/code/klvdata/misb0102.py
+++ b/code/klvdata/misb0102.py
@@ -85,7 +85,7 @@ class SecurityLocalMetadataSet(SetParser):
     Must be a subclass of Element or duck type Element.
     """
     key, name = b'\x30', "Security Local Metadata Set"
-
+    key_length = 1
     TAG = 48
     UDSKey = hexstr_to_bytes('06 0E 2B 34 - 02 03 01 01 – 0E 01 03 03 - 02 00 00 00')
     LDSName = "Security Local Metadata Set"


### PR DESCRIPTION
Missed key_length for security local dataset. Now these info will display on the metadata pack.
